### PR TITLE
FEATURE: Added google chrome renderer to the plugin

### DIFF
--- a/classes/ChromePdfGenerator.php
+++ b/classes/ChromePdfGenerator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Initbiz\PDFGenerator\Classes;
+
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class ChromePdfGenerator
+{
+    public string $executable;
+    public array $options = ['--no-sandbox',
+        '--headless=new',
+        '--disable-gpu',
+        '--run-all-compositor-stages-before-draw',
+        '--virtual-time-budget=5000'];
+    public string $baseTemp;
+
+    public function __construct($storagePath = "app/tmp", $executable = "google-chrome-stable"){
+        // Prepare base temp directory
+        $this->executable = $executable;
+        $this->prepareBaseTemp($storagePath);
+        $this->prepareCatalog();
+    }
+
+    public function prepareBaseTemp($storagePath){
+        $this->baseTemp = storage_path($storagePath);
+        if (!is_dir($this->baseTemp)) {
+            mkdir($this->baseTemp, 0755, true);
+        }
+    }
+
+    public function prepareCatalog(){
+        // Create isolated user-data-dir for Chrome
+        $userDataDir = $this->baseTemp . DIRECTORY_SEPARATOR . 'chrome_user_data';
+        if (!is_dir($userDataDir)) {
+            mkdir($userDataDir, 0700, true);
+        }
+        $this->options[] = '--user-data-dir=' . escapeshellarg($userDataDir);
+    }
+
+    /**
+     * Generate a PDF from raw HTML using headless Chrome,
+     * ensuring a writable user-data directory and full completion.
+     *
+     * @param string $html The raw HTML content to convert.
+     * @param string $filename Desired PDF filename (with or without .pdf extension).
+     * @param array $options Optional Chrome CLI flags (without URL or --print-to-pdf).
+     * @return string            Full path to the generated PDF file in the temp folder.
+     * @throws \RuntimeException If PDF generation fails or output is missing.
+     */
+    public function generate(string $html, string $filename, array $options = []): string
+    {
+        // Create temporary HTML file
+        $htmlPath = $this->baseTemp . DIRECTORY_SEPARATOR . 'chrome_html_' . uniqid() . '.html';
+        file_put_contents($htmlPath, $html);
+
+        // Normalize PDF filename and ensure storage dir exists
+        $filename = pathinfo($filename, PATHINFO_EXTENSION) === 'pdf' ? $filename : $filename . '.pdf';
+        $outputPath = $filename;
+
+        // Default Chrome flags
+
+        $this->options[] = "--print-to-pdf=" . escapeshellarg($outputPath);
+
+        // Build full command and merge stderr/stdout
+        $cmd = array_merge([$this->executable], $this->options, $options, [escapeshellarg($htmlPath)]);
+        $cmdString = implode(' ', $cmd) . ' 2>&1';
+        $process = Process::fromShellCommandline($cmdString);
+        $process->setTimeout(null);
+
+        // Ensure Chrome runs under a writable HOME
+        $process->setEnv(['HOME' => $this->baseTemp]);
+
+        try {
+            $process->mustRun();
+        } catch (ProcessFailedException $e) {
+            @unlink($htmlPath);
+            $output = trim($process->getErrorOutput() ?: $process->getOutput());
+            throw new \RuntimeException('PDF generation failed: ' . $e->getMessage() . '\nChrome output: ' . $output);
+        }
+
+        @unlink($htmlPath);
+
+        // Wait for any remaining Chrome child processes
+        if (!$process->isTerminated()) {
+            $process->wait();
+        }
+
+        // Verify output file
+        if (!file_exists($outputPath)) {
+            $msg = trim($process->getOutput() . ' ' . $process->getErrorOutput());
+            throw new \RuntimeException("PDF not found at {$outputPath}. Output: {$msg}");
+        }
+
+        return $outputPath;
+    }
+}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -20,6 +20,9 @@
         'pdf_rm_older_than_comment' => 'In seconds time to store PDFs. By default 172800 - two days',
         'pdf_binary_label' => 'Binary path',
         'pdf_binary_comment' => 'Path to wkhtmltopdf, you can start the path with \~ (root path) or \$ (plugins path)',
+        'pdf_engine_label' => 'Engine Used',
+        'pdf_engine_comment' => 'Select the engine you want to use, Snappypdf is the reliable and secure pick. Google chrome is experimental, allows rendering modern js and css!',
+        'pdf_binary_comment_chrome' => 'Path of your google-chrome binary',
     ],
     'permissions' => [
         'pdfgenerator_tab' => 'PDF Generator',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -23,6 +23,7 @@
         'pdf_engine_label' => 'Engine Used',
         'pdf_engine_comment' => 'Select the engine you want to use, Snappypdf is the reliable and secure pick. Google chrome is experimental, allows rendering modern js and css!',
         'pdf_binary_comment_chrome' => 'Path of your google-chrome binary',
+        'pdf_generator_options_comment_chrome' => 'key-value pair for google chrome cli options',
     ],
     'permissions' => [
         'pdfgenerator_tab' => 'PDF Generator',

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -36,4 +36,16 @@ class Settings extends Model
 
         return $parsed;
     }
+
+
+    public function filterFields($fields, $context = null)
+    {
+        $engine = post('pdf_engine', $this->pdf_engine);
+
+        if ($engine === 'snappy') {
+            $fields->pdf_binary->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_binary_comment';
+        } else if ($engine === 'chrome') {
+            $fields->pdf_binary->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_binary_comment_chrome';
+        }
+    }
 }

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -42,10 +42,15 @@ class Settings extends Model
     {
         $engine = post('pdf_engine', $this->pdf_engine);
 
-        if ($engine === 'snappy') {
-            $fields->pdf_binary->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_binary_comment';
-        } else if ($engine === 'chrome') {
-            $fields->pdf_binary->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_binary_comment_chrome';
-        }
+        // let it fail
+        try {
+            if ($engine === 'snappy') {
+                $fields->pdf_generator_options->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_generator_options_comment';
+                $fields->pdf_binary->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_binary_comment';
+            } else if ($engine === 'chrome') {
+                $fields->pdf_generator_options->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_generator_options_comment_chrome';
+                $fields->pdf_binary->commentAbove = 'initbiz.pdfgenerator::lang.settings.pdf_binary_comment_chrome';
+            }
+        }catch (\Exception $ex){}
     }
 }

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -20,7 +20,7 @@ tabs:
             commentAbove: initbiz.pdfgenerator::lang.settings.pdf_tokenize_comment
             type: switch
             default: true
-            
+
         pdf_dir:
             label: initbiz.pdfgenerator::lang.settings.pdf_dir_label
             tab: initbiz.pdfgenerator::lang.settings.download_tab
@@ -56,3 +56,14 @@ tabs:
             label: initbiz.pdfgenerator::lang.settings.pdf_binary_label
             tab: initbiz.pdfgenerator::lang.settings.download_tab
             commentAbove: initbiz.pdfgenerator::lang.settings.pdf_binary_comment
+            dependsOn: [pdf_engine]
+
+        pdf_engine:
+            label: initbiz.pdfgenerator::lang.settings.pdf_engine_label
+            tab: initbiz.pdfgenerator::lang.settings.generator_tab
+            commentAbove: initbiz.pdfgenerator::lang.settings.pdf_engine_comment
+            type: dropdown
+            default: snappy
+            options:
+                snappy: SnappyPdf
+                chrome: Google Chrome (EXPERIMENTAL)

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -13,6 +13,7 @@ tabs:
                     value:
                         type: text
                         span: auto
+            dependsOn: [pdf_engine]
 
         pdf_tokenize:
             label: initbiz.pdfgenerator::lang.settings.pdf_tokenize_label

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -18,3 +18,5 @@
     - 'downloadPdfDirectly to get PDFs using data-request-download without redirect and generator options in settings'
 1.2.0:
     - 'Allow generator options without value'
+1.3.0:
+    - 'Add support for google chrome rendering engine'


### PR DESCRIPTION
This PR introduces an additional PDF renderer alongside the existing `SnappyPdf` integration. The new renderer uses **Google Chrome** in headless mode to convert prepared HTML files into PDFs. This approach leverages the latest advancements in CSS and JavaScript rendering, allowing for more modern and dynamic layouts compared to the legacy `wkhtmltopdf` tool.

### ⚠️ Marked as Experimental:

Due to the **broad surface area for potential exploits** and Chrome’s full-featured rendering engine, this feature is marked **experimental**. Use with caution in untrusted environments or consider sandboxing when handling user-supplied HTML.

### Why:

`wkhtmltopdf` is no longer actively maintained and lacks support for modern web standards. This Chrome-based solution offers a future-proof and standards-compliant alternative, without sacrificing output quality or flexibility.